### PR TITLE
Add basic script to update tag used by a build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build-files.txt

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project contains file(s) for common configuration of access to secured bina
 
 ## Files
 
+### bulk-update.sh
+
+Iterates over files defined (one per line, absolute paths) in `./build-files.txt`, replacing tagged uses of files from this repository. Takes a single argument, the tag to update to
+
 ### artifactory-credentials.gradle
 
 This file allows configuration of a set of username/password credentials via either environment variables or Gradle properties in the user's "Gradle Home" to be applied to a sub-set of the repositories Gradle accesses

--- a/bulk-update.sh
+++ b/bulk-update.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied - tag name required"
+    exit 1
+fi
+
+input="build-files.txt"
+
+while IFS= read -r var
+do
+  echo "Updating binary access imports in file $var"
+  sed -i "s#https://raw.githubusercontent.com/blackducksoftware/binary-access-configuration/.*/#https://raw.githubusercontent.com/blackducksoftware/binary-access-configuration/$1/#" $var
+done < "$input"


### PR DESCRIPTION
Adds a basic script which can allow scaling of effort to updating version numbers

Just does basic substitution for now - the INF team may later wish to enhance this with automated creation of a branch for changes, committing of the changes to that branch, and pushing that branch to remote